### PR TITLE
Get rid of superagent and object-assigns dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # superagent-use
 
-Global plugin support for SuperAgent
+Global plugin support for [SuperAgent](https://github.com/visionmedia/superagent/);
 
 ## Summary
 
@@ -10,7 +10,10 @@ Instead of manually calling `use()` for every request, `use()` is called automat
 
 ```js
 
-var superagent = require('superagent-use');
+var superagent = require('superagent');
+/* Pass the superagent object to superagent-use
+   in order to be provided with new `use` functionality */
+require('superagent-use')(superagent);
 var prefix = require('superagent-prefix')('https://api.example.com');
 
 superagent.use(prefix);
@@ -22,5 +25,5 @@ superagent
     console.log(req.url); // => https://api.example.com/auth
   })
   .end(function(err, res) {
-    // 
+    //
   });

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # superagent-use
 
-Global plugin support for [SuperAgent](https://github.com/visionmedia/superagent/);
+Global plugin support for [SuperAgent](https://github.com/visionmedia/superagent/).
 
 ## Summary
 
@@ -9,16 +9,13 @@ Instead of manually calling `use()` for every request, `use()` is called automat
 ## Example
 
 ```js
+/* The superagent-use module returns a clone of the superagent provided with the new functionality. */
+var agent = require('superagent-use')(require('superagent'));
+var prefix = require('superagent-prefix'); /* A sample superagent plugin/middleware. */
 
-var superagent = require('superagent');
-/* Pass the superagent object to superagent-use
-   in order to be provided with new `use` functionality */
-require('superagent-use')(superagent);
-var prefix = require('superagent-prefix')('https://api.example.com');
+agent.use(prefix('https://api.example.com'));
 
-superagent.use(prefix);
-
-superagent
+agent
   .post('/auth')
   .send({user: 'foo', pass: 'bar123'})
   .on('request', function(req) {
@@ -27,3 +24,4 @@ superagent
   .end(function(err, res) {
     //
   });
+```

--- a/index.js
+++ b/index.js
@@ -1,25 +1,27 @@
-var _superagent = require('superagent');
 var methods = require('methods');
-var assign = require('object-assign');
 
-var uses = [];
+module.exports = function(superagent) {
+  var uses = [];
 
-var superagent = assign({}, _superagent);
-
-superagent.use = function(fn) {
-  uses.push(fn);
-  return this;
-};
-
-methods.indexOf('del') == -1 && methods.push('del');
-methods.forEach(function(method) {
-  superagent[method] = function() {
-    var request = _superagent[method].apply(superagent, arguments);
-    uses.forEach(function(use) {
-      request = request.use(use);
-    });
-    return request;
+  superagent.use = function(fn) {
+    uses.push(fn);
+    return this;
   };
-});
 
-module.exports = superagent;
+  if(methods.indexOf('del') === -1) {
+    methods = methods.slice(0);
+    methods.push('del');
+  }
+  methods.forEach(function(method) {
+    var _method = superagent[method];
+    superagent[method] = function() {
+      var request = _method.apply(this, arguments);
+      uses.forEach(function(use) {
+        request = request.use(use);
+      })
+      return request;
+    };
+  });
+
+  return superagent;
+};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var methods = require('methods');
+var extend = require('extend');
 
-module.exports = function(superagent) {
+module.exports = function(_superagent) {
+  var superagent = extend({}, _superagent);
+
   var uses = [];
 
   superagent.use = function(fn) {
@@ -13,9 +16,8 @@ module.exports = function(superagent) {
     methods.push('del');
   }
   methods.forEach(function(method) {
-    var _method = superagent[method];
     superagent[method] = function() {
-      var request = _method.apply(this, arguments);
+      var request = _superagent[method].apply(superagent, arguments);
       uses.forEach(function(use) {
         request = request.use(use);
       })

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "homepage": "https://github.com/koenpunt/superagent-use.git",
   "devDependencies": {
     "mocha": "~2.4.5",
-    "should": "~8.2.2"
+    "should": "~8.2.2",
+    "superagent": "~2.2.0"
   },
   "dependencies": {
-    "methods": "~1.1.2",
-    "object-assign": "~4.0.1",
-    "superagent": "~1.0"
+    "methods": "~1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "superagent": "~2.2.0"
   },
   "dependencies": {
+    "extend": "^3.0.0",
     "methods": "~1.1.2"
   }
 }


### PR DESCRIPTION
Fixes #2.
This:
- gets rid of superagent and object-assigns dependencies
- cleans the tests a bit
- updates the README accordingly
