### PR TITLE
Apply plugins when used as `superagent.method(...args, callback)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,16 @@ module.exports = function(_superagent) {
   }
   methods.forEach(function(method) {
     superagent[method] = function() {
-      var request = _superagent[method].apply(superagent, arguments);
+      var args = [].slice.call(arguments), cb;
+      if (typeof args[args.length-1] === 'function') {
+        cb = args[args.length-1];
+        args = args.slice(0, -1);
+      }
+      var request = _superagent[method].apply(superagent, args);
       uses.forEach(function(use) {
         request = request.use(use);
       })
+      if (cb) request.end(cb)
       return request;
     };
   });

--- a/test/index.js
+++ b/test/index.js
@@ -44,4 +44,14 @@ describe('superagent-use', function() {
      withPrefix.get('/').request()._headers.host.should.equal('example.com');
      withoutPrefix.get('/').request()._headers.host.should.not.equal('example.com');
    });
+
+  it('should work with method(...args, cb)', function(done) {
+    var agent = require('..')(superagent)
+      .use(req => (req.end = fn => fn(null, 'foo'), req));
+
+    agent.get('bar', function(err, res) {
+      res.should.equal('foo');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
`superagent.method(...args, callback)` currently fails to properly apply the plugins, because the request is already sent by the time the plugins are applied with `use()`. This patch fixes that.